### PR TITLE
Don't detect *.jst.eco files, detect *.ejs instead

### DIFF
--- a/ftdetect/jst.vim
+++ b/ftdetect/jst.vim
@@ -1,2 +1,2 @@
-au BufNewFile,BufRead *.jst.*		set filetype=jst
+au BufNewFile,BufRead *.ejs		set filetype=jst
 au BufNewFile,BufRead *.jst  		set filetype=jst


### PR DESCRIPTION
The convention for working with eco files seems to be `filename.jst.eco`, but this plugin detects them as `jst` files instead. This is somewhat related to pull request #6.
