### PR TITLE
Add hamljs fileextension to ftdetect/jst.vim

### DIFF
--- a/ftdetect/jst.vim
+++ b/ftdetect/jst.vim
@@ -1,2 +1,3 @@
 au BufNewFile,BufRead *.ejs		set filetype=jst
 au BufNewFile,BufRead *.jst  		set filetype=jst
+au BufNewFile,BufRead *.hamljs set filetype=jst


### PR DESCRIPTION
To automatically use the right file type for hamljs files, which are
supported since e111089.
